### PR TITLE
UseUrls and Minimal APIs

### DIFF
--- a/TodoApi/Program.cs
+++ b/TodoApi/Program.cs
@@ -11,6 +11,8 @@ builder.Services.AddSwaggerGen(c =>
     c.SwaggerDoc("v1", new() { Title = builder.Environment.ApplicationName, Version = "v1" });
 });
 
+builder.WebHost.UseUrls("http://*:8080");
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())

--- a/TodoApi/Properties/launchSettings.json
+++ b/TodoApi/Properties/launchSettings.json
@@ -14,7 +14,6 @@
       "launchBrowser": true,
       "launchUrl": "swagger",
       "hotReloadProfile": "aspnetcore",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/TodoApi/appsettings.json
+++ b/TodoApi/appsettings.json
@@ -6,5 +6,5 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  
 }


### PR DESCRIPTION
Hi,

Weird way of asking, sorry about that. But shouldn't this resolve to port 8080? For me, it just binds to the default port 5000.

```
➜  TodoApi git:(main) ✗ docker run -v $(pwd):/out mcr.microsoft.com/dotnet/sdk:6.0 dotnet run --project /out
Building...
info: Microsoft.Hosting.Lifetime[14]
      Now listening on: http://localhost:5000
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: /out
```

```
 TodoApi git:(main) docker run -v $(pwd):/out mcr.microsoft.com/dotnet/sdk:6.0 dotnet --info            
.NET SDK (reflecting any global.json):
 Version:   6.0.100-preview.7.21379.14
 Commit:    22d70b47bc

Runtime Environment:
 OS Name:     debian
 OS Version:  11
 OS Platform: Linux
 RID:         linux-x64
 Base Path:   /usr/share/dotnet/sdk/6.0.100-preview.7.21379.14/

Host (useful for support):
  Version: 6.0.0-preview.7.21377.19
  Commit:  91ba01788d

.NET SDKs installed:
  6.0.100-preview.7.21379.14 [/usr/share/dotnet/sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 6.0.0-preview.7.21378.6 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 6.0.0-preview.7.21377.19 [/usr/share/dotnet/shared/Microsoft.NETCore.App]
 ```
  
Edit: Found the `app.Run(urls)` to work as expected, so I guess a minor bug in the WebHost APIs for now.

```diff
- builder.WebHost.UseUrls("http://*:8080");
+ app.Run("http://*:1333");
```
